### PR TITLE
Fix splash on buttons

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       name: flushbar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -75,7 +75,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.15"
+    version: "1.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -87,7 +87,7 @@ packages:
       name: font_awesome_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.5.0"
+    version: "8.8.1"
   intl:
     dependency: "direct main"
     description:
@@ -129,14 +129,14 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "4.3.2+2"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -207,4 +207,4 @@ packages:
     version: "2.0.8"
 sdks:
   dart: ">=2.9.0-14.0.dev <3.0.0"
-  flutter: ">=1.12.1 <2.0.0"
+  flutter: ">=1.16.0 <2.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,7 +75,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.14"
+    version: "1.0.15"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/flutter_login.dart
+++ b/lib/flutter_login.dart
@@ -112,7 +112,7 @@ class __HeaderState extends State<_Header> {
     final renderParagraph = RenderParagraph(
       TextSpan(
         text: widget.title,
-        style: theme.textTheme.display2.copyWith(
+        style: theme.textTheme.headline3.copyWith(
           fontSize: widget.loginTheme.beforeHeroFontSize,
         ),
       ),
@@ -172,14 +172,14 @@ class __HeaderState extends State<_Header> {
         tag: widget.titleTag,
         largeFontSize: widget.loginTheme.beforeHeroFontSize,
         smallFontSize: widget.loginTheme.afterHeroFontSize,
-        style: theme.textTheme.display2,
+        style: theme.textTheme.headline3,
         viewState: ViewState.enlarged,
       );
     } else if (!DartHelper.isNullOrEmpty(widget.title)) {
       title = Text(
         widget.title,
         key: kTitleKey,
-        style: theme.textTheme.display2,
+        style: theme.textTheme.headline3,
       );
     } else {
       title = null;
@@ -444,22 +444,22 @@ class _FlutterLoginState extends State<FlutterLogin>
     final accentColor = loginTheme.accentColor ?? theme.accentColor;
     final errorColor = loginTheme.errorColor ?? theme.errorColor;
     // the background is a dark gradient, force to use white text if detect default black text color
-    final isDefaultBlackText = theme.textTheme.display2.color ==
-        Typography.blackMountainView.display2.color;
-    final titleStyle = theme.textTheme.display2
+    final isDefaultBlackText = theme.textTheme.headline3.color ==
+        Typography.blackMountainView.headline3.color;
+    final titleStyle = theme.textTheme.headline3
         .copyWith(
           color: loginTheme.accentColor ??
               (isDefaultBlackText
                   ? Colors.white
-                  : theme.textTheme.display2.color),
+                  : theme.textTheme.headline3.color),
           fontSize: loginTheme.beforeHeroFontSize,
           fontWeight: FontWeight.w300,
         )
         .merge(loginTheme.titleStyle);
-    final textStyle = theme.textTheme.body1
+    final textStyle = theme.textTheme.bodyText2
         .copyWith(color: Colors.black54)
         .merge(loginTheme.bodyStyle);
-    final textFieldStyle = theme.textTheme.subhead
+    final textFieldStyle = theme.textTheme.subtitle1
         .copyWith(color: Colors.black.withOpacity(.65), fontSize: 14)
         .merge(loginTheme.textFieldStyle);
     final buttonStyle = theme.textTheme.button
@@ -529,13 +529,13 @@ class _FlutterLoginState extends State<FlutterLogin>
         highlightElevation: buttonTheme.highlightElevation ?? 2.0,
         shape: buttonTheme.shape ?? StadiumBorder(),
       ),
-      // put it here because floatingActionButtonTheme doesnt have highlightColor property
+      // put it here because floatingActionButtonTheme doesn't have highlightColor property
       highlightColor:
           loginTheme.buttonTheme.highlightColor ?? theme.highlightColor,
       textTheme: theme.textTheme.copyWith(
-        display2: titleStyle,
-        body1: textStyle,
-        subhead: textFieldStyle,
+        headline3: titleStyle,
+        bodyText2: textStyle,
+        subtitle1: textFieldStyle,
         button: buttonStyle,
       ),
     );
@@ -548,7 +548,7 @@ class _FlutterLoginState extends State<FlutterLogin>
     final deviceSize = MediaQuery.of(context).size;
     const headerMargin = 15;
     const cardInitialHeight = 300;
-    final cardTopPosition = deviceSize.height / 2 - cardInitialHeight / 2;
+    final cardTopPosition = deviceSize.height / (1.8) - cardInitialHeight / (1.8);
     final headerHeight = cardTopPosition - headerMargin;
     final emailValidator =
         widget.emailValidator ?? FlutterLogin.defaultEmailValidator;

--- a/lib/src/widgets/auth_card.dart
+++ b/lib/src/widgets/auth_card.dart
@@ -653,6 +653,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
             child: Card(
               color: theme.primaryColor,
               child: InkWell(
+                radius: 48,
                 child: Icon(
                   loginProvider.icon,
                   color: theme.primaryTextTheme.bodyText1.color,

--- a/lib/src/widgets/auth_card.dart
+++ b/lib/src/widgets/auth_card.dart
@@ -157,12 +157,8 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
   }
 
   Future<void> _forwardChangeRouteAnimation() {
-    final isLogin = Provider
-        .of<Auth>(context, listen: false)
-        .isLogin;
-    final deviceSize = MediaQuery
-        .of(context)
-        .size;
+    final isLogin = Provider.of<Auth>(context, listen: false).isLogin;
+    final deviceSize = MediaQuery.of(context).size;
     final cardSize = getWidgetSize(_cardKey);
     // add .25 to make sure the scaling will cover the whole screen
     final widthRatio = deviceSize.width / cardSize.height + (isLogin ? .25 : .65);
@@ -206,13 +202,11 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
     // loading at startup
     card = AnimatedBuilder(
       animation: _flipAnimation,
-      builder: (context, child) =>
-          Transform(
-            transform: Matrix.perspective()
-              ..rotateX(_flipAnimation.value),
-            alignment: Alignment.center,
-            child: child,
-          ),
+      builder: (context, child) => Transform(
+        transform: Matrix.perspective()..rotateX(_flipAnimation.value),
+        alignment: Alignment.center,
+        child: child,
+      ),
       child: child,
     );
 
@@ -221,15 +215,14 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
       padding: theme.cardTheme.margin,
       child: AnimatedBuilder(
         animation: _cardOverlayHeightFactorAnimation,
-        builder: (context, child) =>
-            ClipPath.shape(
-              shape: theme.cardTheme.shape,
-              child: FractionallySizedBox(
-                heightFactor: _cardOverlayHeightFactorAnimation.value,
-                alignment: Alignment.topCenter,
-                child: child,
-              ),
-            ),
+        builder: (context, child) => ClipPath.shape(
+          shape: theme.cardTheme.shape,
+          child: FractionallySizedBox(
+            heightFactor: _cardOverlayHeightFactorAnimation.value,
+            alignment: Alignment.topCenter,
+            child: child,
+          ),
+        ),
         child: DecoratedBox(
           decoration: BoxDecoration(color: theme.accentColor),
         ),
@@ -255,9 +248,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final deviceSize = MediaQuery
-        .of(context)
-        .size;
+    final deviceSize = MediaQuery.of(context).size;
     Widget current = Container(
       height: deviceSize.height,
       width: deviceSize.width,
@@ -274,24 +265,24 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
         itemBuilder: (BuildContext context, int index) {
           final child = (index == 0)
               ? _buildLoadingAnimator(
-            theme: theme,
-            child: _LoginCard(
-              key: _cardKey,
-              loadingController: _isLoadingFirstTime ? _formLoadingController : (_formLoadingController..value = 1.0),
-              emailValidator: widget.emailValidator,
-              passwordValidator: widget.passwordValidator,
-              onSwitchRecoveryPassword: () => _switchRecovery(true),
-              onSubmitCompleted: () {
-                _forwardChangeRouteAnimation().then((_) {
-                  widget?.onSubmitCompleted();
-                });
-              },
-            ),
-          )
+                  theme: theme,
+                  child: _LoginCard(
+                    key: _cardKey,
+                    loadingController: _isLoadingFirstTime ? _formLoadingController : (_formLoadingController..value = 1.0),
+                    emailValidator: widget.emailValidator,
+                    passwordValidator: widget.passwordValidator,
+                    onSwitchRecoveryPassword: () => _switchRecovery(true),
+                    onSubmitCompleted: () {
+                      _forwardChangeRouteAnimation().then((_) {
+                        widget?.onSubmitCompleted();
+                      });
+                    },
+                  ),
+                )
               : _RecoverCard(
-            emailValidator: widget.emailValidator,
-            onSwitchLogin: () => _switchRecovery(false),
-          );
+                  emailValidator: widget.emailValidator,
+                  onSwitchLogin: () => _switchRecovery(false),
+                );
 
           return Align(
             alignment: Alignment.topCenter,
@@ -308,7 +299,8 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
           alignment: Alignment.center,
           transform: Matrix4.identity()
             ..rotateZ(_cardRotationAnimation.value)
-            ..scale(_cardSizeAnimation.value, _cardSizeAnimation.value)..scale(_cardSize2AnimationX.value, _cardSize2AnimationY.value),
+            ..scale(_cardSizeAnimation.value, _cardSizeAnimation.value)
+            ..scale(_cardSize2AnimationX.value, _cardSize2AnimationY.value),
           child: current,
         );
       },
@@ -382,8 +374,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
           vsync: this,
           duration: Duration(milliseconds: 1150),
           reverseDuration: Duration(milliseconds: 300),
-        )
-          ..value = 1.0);
+        )..value = 1.0);
 
     _loadingController?.addStatusListener(handleLoadingAnimationStatus);
 
@@ -401,12 +392,11 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     );
     _providerControllerList = auth.loginProvidersList
         .map(
-          (e) =>
-          AnimationController(
+          (e) => AnimationController(
             vsync: this,
             duration: Duration(milliseconds: 1000),
           ),
-    )
+        )
         .toList();
 
     _nameTextFieldLoadingAnimationInterval = const Interval(0, .85);
@@ -587,11 +577,11 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       onFieldSubmitted: (value) => _submit(),
       validator: auth.isSignup
           ? (value) {
-        if (value != _passController.text) {
-          return messages.confirmPasswordError;
-        }
-        return null;
-      }
+              if (value != _passController.text) {
+                return messages.confirmPasswordError;
+              }
+              return null;
+            }
           : (value) => null,
       onSaved: (value) => auth.confirmPassword = value,
     );
@@ -611,10 +601,10 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
         ),
         onPressed: buttonEnabled
             ? () {
-          // save state to populate email field on recovery card
-          _formKey.currentState.save();
-          widget.onSwitchRecoveryPassword();
-        }
+                // save state to populate email field on recovery card
+                _formKey.currentState.save();
+                widget.onSwitchRecoveryPassword();
+              }
             : null,
       ),
     );
@@ -655,7 +645,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     return Theme(
       data: theme,
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: auth.loginProvidersList.map((loginProvider) {
           final int index = auth.loginProvidersList.indexOf(loginProvider);
 
@@ -675,13 +665,12 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
                     color: theme.primaryTextTheme.bodyText1.color,
                   ),
                 ),
-                onTap: () =>
-                    _loginProviderSubmit(
-                      control: _providerControllerList[index],
-                      callback: () {
-                        return loginProvider.callback();
-                      },
-                    ),
+                onTap: () => _loginProviderSubmit(
+                  control: _providerControllerList[index],
+                  callback: () {
+                    return loginProvider.callback();
+                  },
+                ),
                 splashColor: theme.accentColor,
               ),
             ),
@@ -697,9 +686,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     final isLogin = auth.isLogin;
     final messages = Provider.of<LoginMessages>(context, listen: false);
     final theme = Theme.of(context);
-    final deviceSize = MediaQuery
-        .of(context)
-        .size;
+    final deviceSize = MediaQuery.of(context).size;
     final cardWidth = min(deviceSize.width * 0.75, 360.0);
     const cardPadding = 16.0;
     final textFieldWidth = cardWidth - cardPadding * 2;
@@ -746,6 +733,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
                 _buildForgotPassword(theme, messages),
                 _buildSubmitButton(theme, messages, auth),
                 _buildSwitchAuthButton(theme, messages, auth),
+                SizedBox(
+                  height: 8,
+                ),
                 _buildProvidersLogInButton(theme, messages, auth),
               ],
             ),
@@ -857,9 +847,9 @@ class _RecoverCardState extends State<_RecoverCard> with SingleTickerProviderSta
       child: Text(messages.goBackButton),
       onPressed: !_isSubmitting
           ? () {
-        _formRecoverKey.currentState.save();
-        widget.onSwitchLogin();
-      }
+              _formRecoverKey.currentState.save();
+              widget.onSwitchLogin();
+            }
           : null,
       padding: EdgeInsets.symmetric(horizontal: 30.0, vertical: 4),
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
@@ -872,9 +862,7 @@ class _RecoverCardState extends State<_RecoverCard> with SingleTickerProviderSta
     final theme = Theme.of(context);
     final auth = Provider.of<Auth>(context, listen: false);
     final messages = Provider.of<LoginMessages>(context, listen: false);
-    final deviceSize = MediaQuery
-        .of(context)
-        .size;
+    final deviceSize = MediaQuery.of(context).size;
     final cardWidth = min(deviceSize.width * 0.75, 360.0);
     const cardPadding = 16.0;
     final textFieldWidth = cardWidth - cardPadding * 2;

--- a/lib/src/widgets/auth_card.dart
+++ b/lib/src/widgets/auth_card.dart
@@ -1,24 +1,24 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:provider/provider.dart';
 import 'package:transformer_page_view/transformer_page_view.dart';
+
 import '../constants.dart';
+import '../dart_helper.dart';
+import '../matrix.dart';
+import '../models/login_data.dart';
+import '../paddings.dart';
+import '../providers/auth.dart';
+import '../providers/login_messages.dart';
+import '../widget_helper.dart';
 import 'animated_button.dart';
-import 'animated_icon.dart';
 import 'animated_text.dart';
+import 'animated_text_form_field.dart';
 import 'custom_page_transformer.dart';
 import 'expandable_container.dart';
 import 'fade_in.dart';
-import 'animated_text_form_field.dart';
-import '../providers/auth.dart';
-import '../providers/login_messages.dart';
-import '../models/login_data.dart';
-import '../dart_helper.dart';
-import '../matrix.dart';
-import '../paddings.dart';
-import '../widget_helper.dart';
 
 class AuthCard extends StatefulWidget {
   AuthCard({
@@ -92,29 +92,23 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
       duration: Duration(milliseconds: 1100),
     );
 
-    _cardSizeAnimation = Tween<double>(begin: 1.0, end: cardSizeScaleEnd)
-        .animate(CurvedAnimation(
+    _cardSizeAnimation = Tween<double>(begin: 1.0, end: cardSizeScaleEnd).animate(CurvedAnimation(
       parent: _routeTransitionController,
       curve: Interval(0, .27272727 /* ~300ms */, curve: Curves.easeInOutCirc),
     ));
     // replace 0 with minPositive to pass the test
     // https://github.com/flutter/flutter/issues/42527#issuecomment-575131275
-    _cardOverlayHeightFactorAnimation =
-        Tween<double>(begin: double.minPositive, end: 1.0).animate(CurvedAnimation(
+    _cardOverlayHeightFactorAnimation = Tween<double>(begin: double.minPositive, end: 1.0).animate(CurvedAnimation(
       parent: _routeTransitionController,
       curve: Interval(.27272727, .5 /* ~250ms */, curve: Curves.linear),
     ));
-    _cardOverlaySizeAndOpacityAnimation =
-        Tween<double>(begin: 1.0, end: 0).animate(CurvedAnimation(
+    _cardOverlaySizeAndOpacityAnimation = Tween<double>(begin: 1.0, end: 0).animate(CurvedAnimation(
       parent: _routeTransitionController,
       curve: Interval(.5, .72727272 /* ~250ms */, curve: Curves.linear),
     ));
-    _cardSize2AnimationX =
-        Tween<double>(begin: 1, end: 1).animate(_routeTransitionController);
-    _cardSize2AnimationY =
-        Tween<double>(begin: 1, end: 1).animate(_routeTransitionController);
-    _cardRotationAnimation =
-        Tween<double>(begin: 0, end: pi / 2).animate(CurvedAnimation(
+    _cardSize2AnimationX = Tween<double>(begin: 1, end: 1).animate(_routeTransitionController);
+    _cardSize2AnimationY = Tween<double>(begin: 1, end: 1).animate(_routeTransitionController);
+    _cardRotationAnimation = Tween<double>(begin: 0, end: pi / 2).animate(CurvedAnimation(
       parent: _routeTransitionController,
       curve: Interval(.72727272, 1 /* ~300ms */, curve: Curves.easeInOutCubic),
     ));
@@ -156,9 +150,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
         }
       });
     } else if (widget.loadingController.isCompleted) {
-      return _formLoadingController
-          .reverse()
-          .then((_) => widget.loadingController.reverse());
+      return _formLoadingController.reverse().then((_) => widget.loadingController.reverse());
     }
     return Future(null);
   }
@@ -168,34 +160,25 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
     final deviceSize = MediaQuery.of(context).size;
     final cardSize = getWidgetSize(_cardKey);
     // add .25 to make sure the scaling will cover the whole screen
-    final widthRatio =
-        deviceSize.width / cardSize.height + (isLogin ? .25 : .65);
+    final widthRatio = deviceSize.width / cardSize.height + (isLogin ? .25 : .65);
     final heightRatio = deviceSize.height / cardSize.width + .25;
 
-    _cardSize2AnimationX =
-        Tween<double>(begin: 1.0, end: heightRatio / cardSizeScaleEnd)
-            .animate(CurvedAnimation(
+    _cardSize2AnimationX = Tween<double>(begin: 1.0, end: heightRatio / cardSizeScaleEnd).animate(CurvedAnimation(
       parent: _routeTransitionController,
       curve: Interval(.72727272, 1, curve: Curves.easeInOutCubic),
     ));
-    _cardSize2AnimationY =
-        Tween<double>(begin: 1.0, end: widthRatio / cardSizeScaleEnd)
-            .animate(CurvedAnimation(
+    _cardSize2AnimationY = Tween<double>(begin: 1.0, end: widthRatio / cardSizeScaleEnd).animate(CurvedAnimation(
       parent: _routeTransitionController,
       curve: Interval(.72727272, 1, curve: Curves.easeInOutCubic),
     ));
 
     widget?.onSubmit();
 
-    return _formLoadingController
-        .reverse()
-        .then((_) => _routeTransitionController.forward());
+    return _formLoadingController.reverse().then((_) => _routeTransitionController.forward());
   }
 
   void _reverseChangeRouteAnimation() {
-    _routeTransitionController
-        .reverse()
-        .then((_) => _formLoadingController.forward());
+    _routeTransitionController.reverse().then((_) => _formLoadingController.forward());
   }
 
   void runChangeRouteAnimation() {
@@ -284,9 +267,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
                   theme: theme,
                   child: _LoginCard(
                     key: _cardKey,
-                    loadingController: _isLoadingFirstTime
-                        ? _formLoadingController
-                        : (_formLoadingController..value = 1.0),
+                    loadingController: _isLoadingFirstTime ? _formLoadingController : (_formLoadingController..value = 1.0),
                     emailValidator: widget.emailValidator,
                     passwordValidator: widget.passwordValidator,
                     onSwitchRecoveryPassword: () => _switchRecovery(true),
@@ -367,6 +348,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
   AnimationController _switchAuthController;
   AnimationController _postSwitchAuthController;
   AnimationController _submitController;
+
   ///list of AnimationController each one responsible for a authentication provider icon
   List<AnimationController> _providerControllerList = List<AnimationController>();
 
@@ -418,10 +400,8 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
 
     _nameTextFieldLoadingAnimationInterval = const Interval(0, .85);
     _passTextFieldLoadingAnimationInterval = const Interval(.15, 1.0);
-    _textButtonLoadingAnimationInterval =
-        const Interval(.6, 1.0, curve: Curves.easeOut);
-    _buttonScaleAnimation =
-        Tween<double>(begin: 0.0, end: 1.0).animate(CurvedAnimation(
+    _textButtonLoadingAnimationInterval = const Interval(.6, 1.0, curve: Curves.easeOut);
+    _buttonScaleAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(CurvedAnimation(
       parent: _loadingController,
       curve: Interval(.4, 1.0, curve: Curves.easeOutBack),
     ));
@@ -514,8 +494,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     return true;
   }
 
-  Future<bool> _loginProviderSubmit(
-      {AnimationController control, ProviderAuthCallback callback}) async {
+  Future<bool> _loginProviderSubmit({AnimationController control, ProviderAuthCallback callback}) async {
     control.forward();
 
     String error;
@@ -568,8 +547,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       interval: _passTextFieldLoadingAnimationInterval,
       labelText: messages.passwordHint,
       controller: _passController,
-      textInputAction:
-          auth.isLogin ? TextInputAction.done : TextInputAction.next,
+      textInputAction: auth.isLogin ? TextInputAction.done : TextInputAction.next,
       focusNode: _passwordFocusNode,
       onFieldSubmitted: (value) {
         if (auth.isLogin) {
@@ -617,14 +595,16 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       child: FlatButton(
         child: Text(
           messages.forgotPasswordButton,
-          style: theme.textTheme.body1,
+          style: theme.textTheme.bodyText2,
           textAlign: TextAlign.left,
         ),
-        onPressed: buttonEnabled ? () {
-          // save state to populate email field on recovery card
-          _formKey.currentState.save();
-          widget.onSwitchRecoveryPassword();
-        } : null,
+        onPressed: buttonEnabled
+            ? () {
+                // save state to populate email field on recovery card
+                _formKey.currentState.save();
+                widget.onSwitchRecoveryPassword();
+              }
+            : null,
       ),
     );
   }
@@ -661,28 +641,34 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
   }
 
   Widget _buildProvidersLogInButton(ThemeData theme, LoginMessages messages, Auth auth) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: auth.loginProvidersList.map((loginProvider) {
-        int index = auth.loginProvidersList.indexOf(loginProvider);
-        return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 3.0),
-          child: ScaleTransition(
+    return Theme(
+      data: theme,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: auth.loginProvidersList.map((loginProvider) {
+          final int index = auth.loginProvidersList.indexOf(loginProvider);
+
+          return ScaleTransition(
             scale: _buttonScaleAnimation,
-            child: AnimatedIconButton(
-              icon: loginProvider.icon,
-              controller: _providerControllerList[index],
-              tooltip: '',
-              onPressed: () => _loginProviderSubmit(
-                control: _providerControllerList[index],
-                callback: () {
-                  return loginProvider.callback();
-                },
+            child: Card(
+              color: theme.primaryColor,
+              child: InkWell(
+                child: Icon(
+                  loginProvider.icon,
+                  color: theme.primaryTextTheme.bodyText1.color,
+                ),
+                onTap: () => _loginProviderSubmit(
+                  control: _providerControllerList[index],
+                  callback: () {
+                    return loginProvider.callback();
+                  },
+                ),
+                splashColor: theme.accentColor,
               ),
             ),
-          ),
-        );
-      }).toList(),
+          );
+        }).toList(),
+      ),
     );
   }
 
@@ -720,9 +706,7 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
           ExpandableContainer(
             backgroundColor: theme.accentColor,
             controller: _switchAuthController,
-            initialState: isLogin
-                ? ExpandableContainerState.shrunk
-                : ExpandableContainerState.expanded,
+            initialState: isLogin ? ExpandableContainerState.shrunk : ExpandableContainerState.expanded,
             alignment: Alignment.topLeft,
             color: theme.cardTheme.color,
             width: cardWidth,
@@ -772,8 +756,7 @@ class _RecoverCard extends StatefulWidget {
   _RecoverCardState createState() => _RecoverCardState();
 }
 
-class _RecoverCardState extends State<_RecoverCard>
-    with SingleTickerProviderStateMixin {
+class _RecoverCardState extends State<_RecoverCard> with SingleTickerProviderStateMixin {
   final GlobalKey<FormState> _formRecoverKey = GlobalKey();
 
   TextEditingController _nameController;
@@ -851,10 +834,12 @@ class _RecoverCardState extends State<_RecoverCard>
   Widget _buildBackButton(ThemeData theme, LoginMessages messages) {
     return FlatButton(
       child: Text(messages.goBackButton),
-      onPressed: !_isSubmitting ? () {
-        _formRecoverKey.currentState.save();
-        widget.onSwitchLogin();
-      } : null,
+      onPressed: !_isSubmitting
+          ? () {
+              _formRecoverKey.currentState.save();
+              widget.onSwitchLogin();
+            }
+          : null,
       padding: EdgeInsets.symmetric(horizontal: 30.0, vertical: 4),
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       textColor: theme.primaryColor,
@@ -891,7 +876,7 @@ class _RecoverCardState extends State<_RecoverCard>
                   messages.recoverPasswordIntro,
                   key: kRecoverPasswordIntroKey,
                   textAlign: TextAlign.center,
-                  style: theme.textTheme.body1,
+                  style: theme.textTheme.bodyText2,
                 ),
                 SizedBox(height: 20),
                 _buildRecoverNameField(textFieldWidth, messages, auth),
@@ -900,7 +885,7 @@ class _RecoverCardState extends State<_RecoverCard>
                   messages.recoverPasswordDescription,
                   key: kRecoverPasswordDescriptionKey,
                   textAlign: TextAlign.center,
-                  style: theme.textTheme.body1,
+                  style: theme.textTheme.bodyText2,
                 ),
                 SizedBox(height: 26),
                 _buildRecoverButton(theme, messages),

--- a/lib/src/widgets/auth_card.dart
+++ b/lib/src/widgets/auth_card.dart
@@ -644,38 +644,51 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
   Widget _buildProvidersLogInButton(ThemeData theme, LoginMessages messages, Auth auth) {
     return Theme(
       data: theme,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: auth.loginProvidersList.map((loginProvider) {
-          final int index = auth.loginProvidersList.indexOf(loginProvider);
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: 8),
+            child: ScaleTransition(
+              scale: _buttonScaleAnimation,
+              child: Text("or sign in with", textAlign: TextAlign.center, style: TextStyle(fontStyle: FontStyle.italic, fontSize: 12),),
+            ),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: auth.loginProvidersList.map((loginProvider) {
+              final int index = auth.loginProvidersList.indexOf(loginProvider);
 
-          return ScaleTransition(
-            scale: _buttonScaleAnimation,
-            child: Card(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(48),
-              ),
-              color: theme.primaryColor,
-              child: InkWell(
-                borderRadius: BorderRadius.circular(48),
-                child: Padding(
-                  padding: EdgeInsets.all(8),
-                  child: Icon(
-                    loginProvider.icon,
-                    color: theme.primaryTextTheme.bodyText1.color,
+              return ScaleTransition(
+                scale: _buttonScaleAnimation,
+                child: Card(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(48),
+                  ),
+                  color: theme.primaryColor,
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(48),
+                    child: Padding(
+                      padding: EdgeInsets.all(8),
+                      child: Icon(
+                        loginProvider.icon,
+                        color: theme.primaryTextTheme.bodyText1.color,
+                      ),
+                    ),
+                    onTap: () => _loginProviderSubmit(
+                      control: _providerControllerList[index],
+                      callback: () {
+                        return loginProvider.callback();
+                      },
+                    ),
+                    splashColor: theme.accentColor,
                   ),
                 ),
-                onTap: () => _loginProviderSubmit(
-                  control: _providerControllerList[index],
-                  callback: () {
-                    return loginProvider.callback();
-                  },
-                ),
-                splashColor: theme.accentColor,
-              ),
-            ),
-          );
-        }).toList(),
+              );
+            }).toList(),
+          )
+        ],
       ),
     );
   }
@@ -733,10 +746,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
                 _buildForgotPassword(theme, messages),
                 _buildSubmitButton(theme, messages, auth),
                 _buildSwitchAuthButton(theme, messages, auth),
-                SizedBox(
-                  height: 8,
-                ),
-                _buildProvidersLogInButton(theme, messages, auth),
+                if (_providerControllerList.isNotEmpty) ...[
+                  _buildProvidersLogInButton(theme, messages, auth),
+                ]
               ],
             ),
           ),

--- a/lib/src/widgets/auth_card.dart
+++ b/lib/src/widgets/auth_card.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
@@ -654,9 +655,12 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
               color: theme.primaryColor,
               child: InkWell(
                 radius: 48,
-                child: Icon(
-                  loginProvider.icon,
-                  color: theme.primaryTextTheme.bodyText1.color,
+                child: Padding(
+                  padding: EdgeInsets.all(4),
+                  child: Icon(
+                    loginProvider.icon,
+                    color: theme.primaryTextTheme.bodyText1.color,
+                  ),
                 ),
                 onTap: () => _loginProviderSubmit(
                   control: _providerControllerList[index],

--- a/lib/src/widgets/auth_card.dart
+++ b/lib/src/widgets/auth_card.dart
@@ -157,8 +157,12 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
   }
 
   Future<void> _forwardChangeRouteAnimation() {
-    final isLogin = Provider.of<Auth>(context, listen: false).isLogin;
-    final deviceSize = MediaQuery.of(context).size;
+    final isLogin = Provider
+        .of<Auth>(context, listen: false)
+        .isLogin;
+    final deviceSize = MediaQuery
+        .of(context)
+        .size;
     final cardSize = getWidgetSize(_cardKey);
     // add .25 to make sure the scaling will cover the whole screen
     final widthRatio = deviceSize.width / cardSize.height + (isLogin ? .25 : .65);
@@ -202,11 +206,13 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
     // loading at startup
     card = AnimatedBuilder(
       animation: _flipAnimation,
-      builder: (context, child) => Transform(
-        transform: Matrix.perspective()..rotateX(_flipAnimation.value),
-        alignment: Alignment.center,
-        child: child,
-      ),
+      builder: (context, child) =>
+          Transform(
+            transform: Matrix.perspective()
+              ..rotateX(_flipAnimation.value),
+            alignment: Alignment.center,
+            child: child,
+          ),
       child: child,
     );
 
@@ -215,14 +221,15 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
       padding: theme.cardTheme.margin,
       child: AnimatedBuilder(
         animation: _cardOverlayHeightFactorAnimation,
-        builder: (context, child) => ClipPath.shape(
-          shape: theme.cardTheme.shape,
-          child: FractionallySizedBox(
-            heightFactor: _cardOverlayHeightFactorAnimation.value,
-            alignment: Alignment.topCenter,
-            child: child,
-          ),
-        ),
+        builder: (context, child) =>
+            ClipPath.shape(
+              shape: theme.cardTheme.shape,
+              child: FractionallySizedBox(
+                heightFactor: _cardOverlayHeightFactorAnimation.value,
+                alignment: Alignment.topCenter,
+                child: child,
+              ),
+            ),
         child: DecoratedBox(
           decoration: BoxDecoration(color: theme.accentColor),
         ),
@@ -248,7 +255,9 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final deviceSize = MediaQuery.of(context).size;
+    final deviceSize = MediaQuery
+        .of(context)
+        .size;
     Widget current = Container(
       height: deviceSize.height,
       width: deviceSize.width,
@@ -265,24 +274,24 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
         itemBuilder: (BuildContext context, int index) {
           final child = (index == 0)
               ? _buildLoadingAnimator(
-                  theme: theme,
-                  child: _LoginCard(
-                    key: _cardKey,
-                    loadingController: _isLoadingFirstTime ? _formLoadingController : (_formLoadingController..value = 1.0),
-                    emailValidator: widget.emailValidator,
-                    passwordValidator: widget.passwordValidator,
-                    onSwitchRecoveryPassword: () => _switchRecovery(true),
-                    onSubmitCompleted: () {
-                      _forwardChangeRouteAnimation().then((_) {
-                        widget?.onSubmitCompleted();
-                      });
-                    },
-                  ),
-                )
+            theme: theme,
+            child: _LoginCard(
+              key: _cardKey,
+              loadingController: _isLoadingFirstTime ? _formLoadingController : (_formLoadingController..value = 1.0),
+              emailValidator: widget.emailValidator,
+              passwordValidator: widget.passwordValidator,
+              onSwitchRecoveryPassword: () => _switchRecovery(true),
+              onSubmitCompleted: () {
+                _forwardChangeRouteAnimation().then((_) {
+                  widget?.onSubmitCompleted();
+                });
+              },
+            ),
+          )
               : _RecoverCard(
-                  emailValidator: widget.emailValidator,
-                  onSwitchLogin: () => _switchRecovery(false),
-                );
+            emailValidator: widget.emailValidator,
+            onSwitchLogin: () => _switchRecovery(false),
+          );
 
           return Align(
             alignment: Alignment.topCenter,
@@ -299,8 +308,7 @@ class AuthCardState extends State<AuthCard> with TickerProviderStateMixin {
           alignment: Alignment.center,
           transform: Matrix4.identity()
             ..rotateZ(_cardRotationAnimation.value)
-            ..scale(_cardSizeAnimation.value, _cardSizeAnimation.value)
-            ..scale(_cardSize2AnimationX.value, _cardSize2AnimationY.value),
+            ..scale(_cardSizeAnimation.value, _cardSizeAnimation.value)..scale(_cardSize2AnimationX.value, _cardSize2AnimationY.value),
           child: current,
         );
       },
@@ -374,7 +382,8 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
           vsync: this,
           duration: Duration(milliseconds: 1150),
           reverseDuration: Duration(milliseconds: 300),
-        )..value = 1.0);
+        )
+          ..value = 1.0);
 
     _loadingController?.addStatusListener(handleLoadingAnimationStatus);
 
@@ -392,11 +401,12 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     );
     _providerControllerList = auth.loginProvidersList
         .map(
-          (e) => AnimationController(
+          (e) =>
+          AnimationController(
             vsync: this,
             duration: Duration(milliseconds: 1000),
           ),
-        )
+    )
         .toList();
 
     _nameTextFieldLoadingAnimationInterval = const Interval(0, .85);
@@ -577,11 +587,11 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
       onFieldSubmitted: (value) => _submit(),
       validator: auth.isSignup
           ? (value) {
-              if (value != _passController.text) {
-                return messages.confirmPasswordError;
-              }
-              return null;
-            }
+        if (value != _passController.text) {
+          return messages.confirmPasswordError;
+        }
+        return null;
+      }
           : (value) => null,
       onSaved: (value) => auth.confirmPassword = value,
     );
@@ -601,10 +611,10 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
         ),
         onPressed: buttonEnabled
             ? () {
-                // save state to populate email field on recovery card
-                _formKey.currentState.save();
-                widget.onSwitchRecoveryPassword();
-              }
+          // save state to populate email field on recovery card
+          _formKey.currentState.save();
+          widget.onSwitchRecoveryPassword();
+        }
             : null,
       ),
     );
@@ -652,22 +662,26 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
           return ScaleTransition(
             scale: _buttonScaleAnimation,
             child: Card(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(48),
+              ),
               color: theme.primaryColor,
               child: InkWell(
-                radius: 48,
+                borderRadius: BorderRadius.circular(48),
                 child: Padding(
-                  padding: EdgeInsets.all(4),
+                  padding: EdgeInsets.all(8),
                   child: Icon(
                     loginProvider.icon,
                     color: theme.primaryTextTheme.bodyText1.color,
                   ),
                 ),
-                onTap: () => _loginProviderSubmit(
-                  control: _providerControllerList[index],
-                  callback: () {
-                    return loginProvider.callback();
-                  },
-                ),
+                onTap: () =>
+                    _loginProviderSubmit(
+                      control: _providerControllerList[index],
+                      callback: () {
+                        return loginProvider.callback();
+                      },
+                    ),
                 splashColor: theme.accentColor,
               ),
             ),
@@ -683,7 +697,9 @@ class _LoginCardState extends State<_LoginCard> with TickerProviderStateMixin {
     final isLogin = auth.isLogin;
     final messages = Provider.of<LoginMessages>(context, listen: false);
     final theme = Theme.of(context);
-    final deviceSize = MediaQuery.of(context).size;
+    final deviceSize = MediaQuery
+        .of(context)
+        .size;
     final cardWidth = min(deviceSize.width * 0.75, 360.0);
     const cardPadding = 16.0;
     final textFieldWidth = cardWidth - cardPadding * 2;
@@ -841,9 +857,9 @@ class _RecoverCardState extends State<_RecoverCard> with SingleTickerProviderSta
       child: Text(messages.goBackButton),
       onPressed: !_isSubmitting
           ? () {
-              _formRecoverKey.currentState.save();
-              widget.onSwitchLogin();
-            }
+        _formRecoverKey.currentState.save();
+        widget.onSwitchLogin();
+      }
           : null,
       padding: EdgeInsets.symmetric(horizontal: 30.0, vertical: 4),
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
@@ -856,7 +872,9 @@ class _RecoverCardState extends State<_RecoverCard> with SingleTickerProviderSta
     final theme = Theme.of(context);
     final auth = Provider.of<Auth>(context, listen: false);
     final messages = Provider.of<LoginMessages>(context, listen: false);
-    final deviceSize = MediaQuery.of(context).size;
+    final deviceSize = MediaQuery
+        .of(context)
+        .size;
     final cardWidth = min(deviceSize.width * 0.75, 360.0);
     const cardPadding = 16.0;
     final textFieldWidth = cardWidth - cardPadding * 2;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_login
 description: A login widget with login/signup functionalities to help speed up development
-version: 1.0.14
+version: 1.0.15
 author: NearHuscarl <near.huscarl@gmail.com>
 homepage: https://github.com/NearHuscarl/flutter_login
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_login
 description: A login widget with login/signup functionalities to help speed up development
-version: 1.0.15
+version: 1.1.0
 author: NearHuscarl <near.huscarl@gmail.com>
 homepage: https://github.com/NearHuscarl/flutter_login
 
@@ -10,12 +10,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  font_awesome_flutter: ^8.5.0
-  provider: ^4.0.2
+  font_awesome_flutter: ^8.8.1
+  provider: ^4.3.2+2
   transformer_page_view: ^0.1.6
-  flushbar: ^1.9.1
+  flushbar: ^1.10.4
   # flutter_test from sdk depends on quiver 2.0.5
-  quiver: ^2.0.5
+  quiver: ^2.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR fixes the splash on the third-party provider buttons so that it doesn't overflow

Also adds a text line "or sign in with" if at least one third-party provider button is present

Updates some deprecated material theme terms